### PR TITLE
misc: refactored named types of withCallState

### DIFF
--- a/libs/ngrx-toolkit/src/lib/with-call-state.ts
+++ b/libs/ngrx-toolkit/src/lib/with-call-state.ts
@@ -9,26 +9,22 @@ import { Emtpy } from './shared/empty';
 
 export type CallState = 'init' | 'loading' | 'loaded' | { error: string };
 
-export type NamedCallStateSlice<Collection extends string> = {
-  [K in Collection as `${K}CallState`]: CallState;
-};
-
 export type CallStateSlice = {
   callState: CallState
 }
 
-export type NamedCallStateSignals<Prop extends string> = {
-  [K in Prop as `${K}Loading`]: Signal<boolean>;
-} & {
-    [K in Prop as `${K}Loaded`]: Signal<boolean>;
-  } & {
-    [K in Prop as `${K}Error`]: Signal<string | null>;
-  }
+export type NamedCallStateSlice<Collection extends string> = {
+  [K in keyof CallStateSlice as `${Collection}${Capitalize<K>}`]: CallStateSlice[K];
+}
 
 export type CallStateSignals = {
   loading: Signal<boolean>;
   loaded: Signal<boolean>;
   error: Signal<string | null>
+}
+
+export type NamedCallStateSignals<Prop extends string> = {
+  [K in keyof CallStateSignals as `${Prop}${Capitalize<K>}`]: CallStateSignals[K];
 }
 
 export type SetCallState<Prop extends string | undefined> = Prop extends string


### PR DESCRIPTION
This is a suggestion for an easier mapping of the state and signal types to the named (collection) types.

If you're ok with this I can take a look at the other mappings.

I've also reordered them so that the dependent type comes first.