### PR TITLE
feat(devtools): rename `patchState` to `updateState`

### DIFF
--- a/apps/demo/src/app/flight-search/flight-store.ts
+++ b/apps/demo/src/app/flight-search/flight-store.ts
@@ -4,7 +4,7 @@ import {
   payload,
   withDevtools,
   withRedux,
-  patchState,
+  updateState,
 } from 'ngrx-toolkit';
 import { inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
@@ -28,7 +28,7 @@ export const FlightStore = signalStore(
 
     reducer: (actions, on) => {
       on(actions.flightsLoaded, (state, { flights }) => {
-        patchState(state, 'flights loaded', { flights });
+        updateState(state, 'flights loaded', { flights });
       });
     },
 

--- a/apps/demo/src/app/todo-store.ts
+++ b/apps/demo/src/app/todo-store.ts
@@ -5,7 +5,7 @@ import {
   updateEntity,
   withEntities,
 } from '@ngrx/signals/entities';
-import { patchState, withDevtools } from 'ngrx-toolkit';
+import { updateState, withDevtools } from 'ngrx-toolkit';
 
 export interface Todo {
   id: number;
@@ -25,16 +25,16 @@ export const TodoStore = signalStore(
     let currentId = 0;
     return {
       add(todo: AddTodo) {
-        patchState(store, 'add todo', setEntity({ id: ++currentId, ...todo }));
+        updateState(store, 'add todo', setEntity({ id: ++currentId, ...todo }));
       },
 
       remove(id: number) {
-        patchState(store, 'remove todo', removeEntity(id));
+        updateState(store, 'remove todo', removeEntity(id));
       },
 
       toggleFinished(id: number): void {
         const todo = store.entityMap()[id];
-        patchState(
+        updateState(
           store,
           'toggle todo',
           updateEntity({ id, changes: { finished: !todo.finished } })

--- a/libs/ngrx-toolkit/src/index.ts
+++ b/libs/ngrx-toolkit/src/index.ts
@@ -1,9 +1,14 @@
-export { withDevtools, patchState, Action } from './lib/with-devtools';
+export {
+  withDevtools,
+  patchState,
+  updateState,
+  Action,
+} from './lib/with-devtools';
 export * from './lib/with-redux';
 
 export * from './lib/with-call-state';
 export * from './lib/with-undo-redo';
-export * from './lib/with-data-service'
+export * from './lib/with-data-service';
 export { withStorageSync, SyncConfig } from './lib/with-storage-sync';
 export * from './lib/redux-connector';
 export * from './lib/redux-connector/rxjs-interop';

--- a/libs/ngrx-toolkit/src/lib/with-devtools.ts
+++ b/libs/ngrx-toolkit/src/lib/with-devtools.ts
@@ -122,7 +122,21 @@ type PatchFn = typeof originalPatchState extends (
   ? (state: First, action: string, ...rest: Rest) => Returner
   : never;
 
+/**
+ * @deprecated Has been renamed to `updateState`
+ */
 export const patchState: PatchFn = (state, action, ...rest) => {
+  updateState(state, action, ...rest);
+};
+
+/**
+ * Wrapper of `patchState` for DevTools integration. Next to updating the state,
+ * it also sends the action to the DevTools.
+ * @param state state of Signal Store
+ * @param action name of action how it will show in DevTools
+ * @param updaters updater functions or objects
+ */
+export const updateState: PatchFn = (state, action, ...updaters) => {
   currentActionNames.add(action);
-  return originalPatchState(state, ...rest);
+  return originalPatchState(state, ...updaters);
 };


### PR DESCRIPTION
The name `patchState` is already used by the SignalStore. For better differentiation, a renaming was necessary.

`patchState` from this library is still available but marked as deprecated.