### PR TITLE
feat: Add local pagination feature

### DIFF
--- a/libs/ngrx-toolkit/package.json
+++ b/libs/ngrx-toolkit/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/angular-architects/ngrx-toolkit"
   },
   "peerDependencies": {
-    "@ngrx/signals": "^17.0.0"
+    "@ngrx/signals": "^17.2.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/ngrx-toolkit/src/index.ts
+++ b/libs/ngrx-toolkit/src/index.ts
@@ -12,3 +12,4 @@ export * from './lib/with-data-service';
 export { withStorageSync, SyncConfig } from './lib/with-storage-sync';
 export * from './lib/redux-connector';
 export * from './lib/redux-connector/rxjs-interop';
+export * from './lib/with-pagination';

--- a/libs/ngrx-toolkit/src/lib/with-pagination.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/with-pagination.spec.ts
@@ -1,0 +1,90 @@
+import { patchState, signalStore, type } from '@ngrx/signals';
+import { createPageArray, gotoPage, setPageSize, withPagination } from './with-pagination';
+import { setAllEntities, withEntities } from '@ngrx/signals/entities';
+
+type Book = { id: number; title: string; author: string };
+const generateBooks = (count = 10) => {
+  const books = [] as Book[];
+  for (let i = 1; i <= count; i++) {
+    books.push({ id: i, title: `Book ${i}`, author: `Author ${i}` });
+  }
+  return books;
+};
+
+describe('withPagination', () => {
+  it('should use and update a pagination', () => {
+    const Store = signalStore(
+      withEntities({ entity: type<Book>() }),
+      withPagination()
+    );
+
+    const store = new Store();
+
+    patchState(store, setAllEntities(generateBooks(55)));
+    expect(store.currentPage()).toBe(1);
+    expect(store.pageCount()).toBe(6);
+  }),
+    it('should use and update a pagination with collection', () => {
+      const Store = signalStore(
+        withEntities({ entity: type<Book>(), collection: 'books' }),
+        withPagination({ collection: 'books' })
+      );
+
+      const store = new Store();
+
+      patchState(
+        store,
+        setAllEntities(generateBooks(55), { collection: 'books' })
+      );
+
+      patchState(store, gotoPage(6, { collection: 'books' }));
+      expect(store.booksCurrentPage()).toBe(6);
+      expect(store.selectedPageBooksEntities().length).toBe(5);
+      expect(store.booksPageCount()).toBe(6);
+    }),
+    it('should react on enitiy changes', () => {
+      const Store = signalStore(
+        withEntities({ entity: type<Book>()}),
+        withPagination()
+      );
+
+      const store = new Store();
+
+      patchState(
+        store,
+        setAllEntities(generateBooks(100))
+      );
+
+      expect(store.pageCount()).toBe(10);
+
+      patchState(
+        store,
+        setAllEntities(generateBooks(20))
+      );
+
+      expect(store.pageCount()).toBe(2);
+
+
+      patchState(
+        store,
+        setPageSize(5)
+      );
+
+      expect(store.pageCount()).toBe(4);
+
+    }),
+    describe('internal pageNavigationArray', () => {
+      it('should return an array of page numbers', () => {
+        const pages = createPageArray(8, 10, 500, 7);
+        expect(pages).toEqual([
+          { label: 5, value: 5 },
+          { label: '...', value: 6 },
+          { label: 7, value: 7 },
+          { label: 8, value: 8 },
+          { label: 9, value: 9 },
+          { label: '...', value: 10 },
+          { label: 50, value: 50 },
+        ]);
+      });
+    });
+});

--- a/libs/ngrx-toolkit/src/lib/with-pagination.ts
+++ b/libs/ngrx-toolkit/src/lib/with-pagination.ts
@@ -1,0 +1,362 @@
+/** With pagination comes in two flavors the first one is local pagination or in memory pagination. For example we have 2000 items which we want
+ * to display in a table and the response payload is small enough to be stored in the memory. But we can not display all 2000 items at once
+ * so we need to paginate the data. The second flavor is server side pagination where the response payload is too large to be stored in the memory
+ * and we need to fetch the data from the server in chunks. In the second case we 'could' also cache the data in the memory but that could lead to
+ * other problems like memory leaks and stale data. So we will not cache the data in the memory in the second case.
+ * This feature implements the local pagination.
+ */
+
+import { Signal, computed } from '@angular/core';
+import {
+  SignalStoreFeature,
+  signalStoreFeature,
+  withComputed,
+  withState,
+} from '@ngrx/signals';
+import { Emtpy } from './shared/empty';
+import {
+  EntitySignals,
+  EntityState,
+  NamedEntitySignals,
+} from '@ngrx/signals/entities/src/models';
+import { Entity, capitalize } from './with-data-service';
+
+// This is a virtual page which is can be used to create a pagination control
+export type Page = { label: string | number; value: number };
+
+export type NamedPaginationServiceState<
+  E extends Entity,
+  Collection extends string
+> = {
+  [K in Collection as `selectedPage${Capitalize<K>}Entities`]: Array<E>;
+} & {
+  [K in Collection as `${Lowercase<K>}CurrentPage`]: number;
+} & {
+  [K in Collection as `${Lowercase<K>}PageSize`]: number;
+} & {
+  [K in Collection as `${Lowercase<K>}TotalCount`]: number;
+} & {
+  [K in Collection as `${Lowercase<K>}PageCount`]: number;
+} & {
+  [K in Collection as `${Lowercase<K>}PageNavigationArray`]: number;
+} & {
+  [K in Collection as `${Lowercase<K>}PageNavigationArrayMax`]: number;
+};
+
+export type NamedPaginationServiceSignals<
+  E extends Entity,
+  Collection extends string
+> = {
+  [K in Collection as `selectedPage${Capitalize<K>}Entities`]: Signal<E[]>;
+} & {
+  [K in Collection as `${Lowercase<K>}CurrentPage`]: Signal<number>;
+} & {
+  [K in Collection as `${Lowercase<K>}PageSize`]: Signal<number>;
+} & {
+  [K in Collection as `${Lowercase<K>}TotalCount`]: Signal<number>;
+} & {
+  [K in Collection as `${Lowercase<K>}PageCount`]: Signal<number>;
+} & {
+  [K in Collection as `${Lowercase<K>}PageNavigationArray`]: Signal<Page[]>;
+} & {
+  [K in Collection as `${Lowercase<K>}PageNavigationArrayMax`]: Signal<number>;
+};
+
+export type PaginationServiceState<E extends Entity> = {
+  selectedPageEntities: Array<E>;
+  currentPage: number;
+  pageSize: number;
+  totalCount: number;
+  pageCount: number;
+  pageNavigationArray: Page[];
+  pageNavigationArrayMax: number;
+};
+
+export type PaginationServiceSignals<E extends Entity> = {
+  selectedPageEntities: Signal<E[]>;
+  currentPage: Signal<number>;
+  pageSize: Signal<number>;
+  totalCount: Signal<number>;
+  pageCount: Signal<number>;
+  pageNavigationArray: Signal<Page[]>;
+  pageNavigationArrayMax: Signal<number>;
+};
+
+export type SetPaginationState<
+  E extends Entity,
+  Collection extends string | undefined
+> = Collection extends string
+  ? NamedPaginationServiceState<E, Collection>
+  : PaginationServiceState<E>;
+
+export function withPagination<
+  E extends Entity,
+  Collection extends string
+>(options: {
+  collection: Collection;
+}): SignalStoreFeature<
+  {
+    state: Emtpy;
+    signals: NamedEntitySignals<E, Collection>;
+    methods: Emtpy;
+  },
+  {
+    state: NamedPaginationServiceState<E, Collection>;
+    signals: NamedPaginationServiceSignals<E, Collection>;
+    methods: Emtpy;
+  }
+>;
+
+export function withPagination<E extends Entity>(): SignalStoreFeature<
+  {
+    state: EntityState<E>;
+    signals: EntitySignals<E>;
+    methods: Emtpy;
+  },
+  {
+    state: PaginationServiceState<E>;
+    signals: PaginationServiceSignals<E>;
+    methods: Emtpy;
+  }
+>;
+
+export function withPagination<
+  E extends Entity,
+  Collection extends string
+>(options?: { collection: Collection }): SignalStoreFeature<any, any> {
+  const {
+    pageKey,
+    pageSizeKey,
+    entitiesKey,
+    selectedPageEntitiesKey,
+    totalCountKey,
+    pageCountKey,
+    pageNavigationArrayMaxKey,
+    pageNavigationArrayKey,
+  } = createPaginationKeys<Collection>(options);
+
+  return signalStoreFeature(
+    withState({
+      [pageKey]: 1,
+      [pageSizeKey]: 10,
+      [pageNavigationArrayMaxKey]: 7,
+    }),
+    withComputed((store: Record<string, unknown>) => {
+      const entities = store[entitiesKey] as Signal<E[]>;
+      const page = store[pageKey] as Signal<number>;
+      const pageSize = store[pageSizeKey] as Signal<number>;
+      const pageNavigationArrayMax = store[
+        pageNavigationArrayMaxKey
+      ] as Signal<number>;
+
+      return {
+        // The derived enitites which are displayed on the current page
+        [selectedPageEntitiesKey]: computed<E[]>(() => {
+          const pageSizeValue = pageSize();
+          const pageValue = page();
+
+          // If the page is greater than the total number of pages
+          // we should return an empty array
+          if (
+            pageValue < 0 ||
+            pageSizeValue === 0 ||
+            pageValue > Math.ceil(entities().length / pageSizeValue)
+          ) {
+            return [] as E[];
+          }
+
+          return entities().slice(
+            (pageValue - 1) * pageSizeValue,
+            pageValue * pageSizeValue
+          ) as E[];
+        }),
+        [totalCountKey]: computed(() => entities().length),
+        [pageCountKey]: computed(() => {
+          const totalCountValue = entities().length;
+          const pageSizeValue = pageSize();
+
+          if (totalCountValue === 0) {
+            return 0;
+          }
+
+          return Math.ceil(totalCountValue / pageSizeValue);
+        }),
+        [pageNavigationArrayKey]: computed(() =>
+          createPageArray(
+            page(),
+            pageSize(),
+            entities().length,
+            pageNavigationArrayMax()
+          )
+        ),
+      };
+    })
+  );
+}
+
+export function gotoPage<E extends Entity, Collection extends string>(
+  page: number,
+  options?: {
+    collection: Collection;
+  }
+): Partial<SetPaginationState<E, Collection>> {
+  const { pageKey } = createPaginationKeys<Collection>(options);
+
+  return {
+    [pageKey]: page,
+  } as Partial<SetPaginationState<E, Collection>>;
+}
+
+export function setPageSize<E extends Entity, Collection extends string>(
+  pageSize: number,
+  options?: {
+    collection: Collection;
+  }
+): Partial<SetPaginationState<E, Collection>> {
+  const { pageSizeKey } = createPaginationKeys<Collection>(options);
+
+  return {
+    [pageSizeKey]: pageSize,
+  } as Partial<SetPaginationState<E, Collection>>;
+}
+
+export function nextPage<
+  E extends Entity,
+  Collection extends string
+>(options?: {
+  collection: Collection;
+}): Partial<SetPaginationState<E, Collection>> {
+  const { pageKey } = createPaginationKeys<Collection>(options);
+
+  return {
+    [pageKey]: (currentPage: number) => currentPage + 1,
+  } as Partial<SetPaginationState<E, Collection>>;
+}
+
+export function previousPage<
+  E extends Entity,
+  Collection extends string
+>(options?: {
+  collection: Collection;
+}): Partial<SetPaginationState<E, Collection>> {
+  const { pageKey } = createPaginationKeys<Collection>(options);
+
+  return {
+    [pageKey]: (currentPage: number) => Math.max(currentPage - 1, 1),
+  } as Partial<SetPaginationState<E, Collection>>;
+}
+
+export function firstPage<
+  E extends Entity,
+  Collection extends string
+>(options?: {
+  collection: Collection;
+}): Partial<SetPaginationState<E, Collection>> {
+  const { pageKey } = createPaginationKeys<Collection>(options);
+
+  return {
+    [pageKey]: 1,
+  } as Partial<SetPaginationState<E, Collection>>;
+}
+
+export function setMaxPageNavigationArrayItems<
+  E extends Entity,
+  Collection extends string
+>(
+  maxPageNavigationArrayItems: number,
+  options?: {
+    collection: Collection;
+  }
+): Partial<SetPaginationState<E, Collection>> {
+  const { pageNavigationArrayMaxKey } =
+    createPaginationKeys<Collection>(options);
+
+  return {
+    [pageNavigationArrayMaxKey]: maxPageNavigationArrayItems,
+  } as Partial<SetPaginationState<E, Collection>>;
+}
+
+function createPaginationKeys<Collection extends string>(
+  options: { collection: Collection } | undefined
+) {
+  const entitiesKey = options?.collection
+    ? `${options.collection}Entities`
+    : 'entities';
+  const selectedPageEntitiesKey = options?.collection
+    ? `selectedPage${capitalize(options?.collection)}Entities`
+    : 'selectedPageEntities';
+  const pageKey = options?.collection ? `${options.collection}CurrentPage` : 'currentPage';
+  const pageSizeKey = options?.collection
+    ? `${options.collection}PageSize`
+    : 'pageSize';
+  const totalCountKey = options?.collection
+    ? `${options.collection}TotalCount`
+    : 'totalCount';
+  const pageCountKey = options?.collection
+    ? `${options.collection}PageCount`
+    : 'pageCount';
+  const pageNavigationArrayMaxKey = options?.collection
+    ? `${options.collection}PageNavigationArrayMax`
+    : 'pageNavigationArrayMax';
+  const pageNavigationArrayKey = options?.collection
+    ? `${options.collection}PageNavigationArray`
+    : 'pageNavigationArray';
+  return {
+    pageKey,
+    pageSizeKey,
+    entitiesKey,
+    selectedPageEntitiesKey,
+    totalCountKey,
+    pageCountKey,
+    pageNavigationArrayKey,
+    pageNavigationArrayMaxKey,
+  };
+}
+
+export function createPageArray(
+  currentPage: number,
+  itemsPerPage: number,
+  totalItems: number,
+  paginationRange: number
+): Page[] {
+  // Convert paginationRange to number in case it's a string
+  paginationRange = +paginationRange;
+
+  // Calculate total number of pages
+  const totalPages = Math.max(Math.ceil(totalItems / itemsPerPage), 1);
+  const halfWay = Math.ceil(paginationRange / 2);
+
+  const isStart = currentPage <= halfWay;
+  const isEnd = totalPages - halfWay < currentPage;
+  const isMiddle = !isStart && !isEnd;
+
+  const ellipsesNeeded = paginationRange < totalPages;
+  const pages: Page[] = [];
+
+  for (let i = 1; i <= totalPages && i <= paginationRange; i++) {
+    let pageNumber = i;
+
+    if (i === paginationRange) {
+      pageNumber = totalPages;
+    } else if (ellipsesNeeded) {
+      if (isEnd) {
+        pageNumber = totalPages - paginationRange + i;
+      } else if (isMiddle) {
+        pageNumber = currentPage - halfWay + i;
+      }
+    }
+
+    const openingEllipsesNeeded = i === 2 && (isMiddle || isEnd);
+    const closingEllipsesNeeded =
+      i === paginationRange - 1 && (isMiddle || isStart);
+
+    const label =
+      ellipsesNeeded && (openingEllipsesNeeded || closingEllipsesNeeded)
+        ? '...'
+        : pageNumber;
+
+    pages.push({ label, value: pageNumber });
+  }
+
+  return pages;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "~17.0.0",
         "@angular/router": "~17.0.0",
         "@angular/ssr": "~17.0.0",
-        "@ngrx/signals": "^17.1.0",
+        "@ngrx/signals": "^17.2.0",
         "@ngrx/store": "^17.1.0",
         "@nx/angular": "18.3.3",
         "express": "~4.18.2",
@@ -5477,9 +5477,9 @@
       }
     },
     "node_modules/@ngrx/signals": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@ngrx/signals/-/signals-17.1.1.tgz",
-      "integrity": "sha512-9Rlw7u8LxkyS+HMZe7DzUkV1p/2IL5tDa1ZHhX8Ldilx4HoOHvISdzCagCpXMoXDLZGEaWOA/n/BcQQxsjytEg==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/signals/-/signals-17.2.0.tgz",
+      "integrity": "sha512-tkkxifeOVPOhpTqbHyK1WOx4qz49HLR/h0vhaa/MRGRIZoOR/6gR4KB3hbC8FD3FdnuNqOgOZ2lGsTfWPB/6BQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-server": "~17.0.0",
     "@angular/router": "~17.0.0",
     "@angular/ssr": "~17.0.0",
-    "@ngrx/signals": "^17.1.0",
+    "@ngrx/signals": "^17.2.0",
     "@ngrx/store": "^17.1.0",
     "@nx/angular": "18.3.3",
     "express": "~4.18.2",


### PR DESCRIPTION
This commit adds the implementation for local pagination in the `withPagination` function. It allows for displaying a subset of items from a larger collection, based on the current page and page size.

The `withPagination` function accepts an optional `collection` parameter to support multiple paginated collections. It calculates the selected page entities, total count, total pages, and page navigation array based on the provided options.

Additionally, utility functions like `gotoPage`, `setPageSize`, `nextPage`, `previousPage`, `firstPage`, and `setMaxPageNavigationArrayItems` are provided to easily update the pagination state.

Export with-pagination

Downgrade signals package

Update signal package