### PR TITLE
fix(undo-redo): prevent duplicated entries on undo stack

### DIFF
--- a/libs/ngrx-toolkit/src/lib/with-undo-redo.ts
+++ b/libs/ngrx-toolkit/src/lib/with-undo-redo.ts
@@ -161,6 +161,16 @@ SignalStoreFeature<any, any> {
                         return;
                     }
 
+                    // 
+                    // Deep Comparison to prevent duplicated entries
+                    // on the stack. This can e.g. happen after an undo 
+                    // if the component sends back the undone filter 
+                    // to the store.
+                    //
+                    if(JSON.stringify(cand) === JSON.stringify(previous)) {
+                        return;
+                    }
+    
                     // Clear redoStack after recorded action
                     redoStack.splice(0);
 


### PR DESCRIPTION
Perform a deep comparison to prevent duplicate entries on the stack. This can, for example, happen after an undo if the component sends back the undone filter to the store.