### PR TITLE
fix: close unterminated code block in `libs/ngrx-toolkit/README.md`

### DIFF
--- a/libs/ngrx-toolkit/README.md
+++ b/libs/ngrx-toolkit/README.md
@@ -270,6 +270,9 @@ public class SyncedStoreComponent {
 
   clearStorage(): void {
     this.syncStore.clearStorage(); // clears the stored item in storage
+  }
+}
+```
 
 ## Redux Connector for the NgRx Signal Store `createReduxState()`
 


### PR DESCRIPTION
Without this fix, the ``## Redux Connector for the NgRx Signal Store `createReduxState()` `` section is absorbed into the code block of the `## Storage Sync withStorageSync()` section.

Also this commit adds some closing `}` to the `withStorageSync` block.