### PR TITLE
docs: Add missing `updateAll` example to `withDataService` interface examples (root & lib)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ export class FlightService implements DataService<Flight, FlightFilter> {
 
   create(entity: Flight): Promise<Flight> { ... }
   update(entity: Flight): Promise<Flight> { ... }
+  updateAll(entity: Flight[]): Promise<Flight[]> { ... }
   delete(entity: Flight): Promise<void> { ... }
   [...]
 }

--- a/libs/ngrx-toolkit/README.md
+++ b/libs/ngrx-toolkit/README.md
@@ -140,6 +140,7 @@ export class FlightService implements DataService<Flight, FlightFilter> {
 
   create(entity: Flight): Promise<Flight> { ... }
   update(entity: Flight): Promise<Flight> { ... }
+  updateAll(entity: Flight[]): Promise<Flight[]> { ... }
   delete(entity: Flight): Promise<void> { ... }
   [...]
 }


### PR DESCRIPTION
I remembered seeing `withDataService` after I read an article that did something like it. I was going to tweak this to use `rxMethod` for my own project, but then I realized the doc pages were missing `updateAll`. 