### PR TITLE
docs: add missed words in `withReset()` description

### DIFF
--- a/docs/docs/with-reset.md
+++ b/docs/docs/with-reset.md
@@ -2,7 +2,7 @@
 title: withReset()
 ---
 
-`withReset()` adds a method the state of the Signal Store to its initial value. Nothing more to say about it 😅
+`withReset()` adds a method to reset the state of the Signal Store to its initial value. Nothing more to say about it 😅
 
 Example:
 


### PR DESCRIPTION
I was checking out the new docs, they are nice to have. Noticed this phrasing was missing a couple words.

Also, `withReset()` is not listed in the sidenav as it is deployed now by the way.