### PR TITLE
docs: make snippet langs consistent & fix example indent

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,13 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 
 ### Installation
 
-```
+```shell
 $ yarn
 ```
 
 ### Local Development
 
-```
+```shell
 $ yarn start
 ```
 
@@ -18,7 +18,7 @@ This command starts a local development server and opens up a browser window. Mo
 
 ### Build
 
-```
+```shell
 $ yarn build
 ```
 
@@ -28,13 +28,13 @@ This command generates static content into the `build` directory and can be serv
 
 Using SSH:
 
-```
+```shell
 $ USE_SSH=true yarn deploy
 ```
 
 Not using SSH:
 
-```
+```shell
 $ GIT_USER=<Your GitHub username> yarn deploy
 ```
 

--- a/docs/docs/with-data-service.md
+++ b/docs/docs/with-data-service.md
@@ -45,38 +45,38 @@ Once the store is defined, it gives its consumers numerous signals and methods t
 ```typescript
 @Component(...)
 export class FlightSearchSimpleComponent {
-private store = inject(SimpleFlightBookingStore);
+  private store = inject(SimpleFlightBookingStore);
 
-from = this.store.filter.from;
-to = this.store.filter.to;
-flights = this.store.entities;
-selected = this.store.selectedEntities;
-selectedIds = this.store.selectedIds;
+  from = this.store.filter.from;
+  to = this.store.filter.to;
+  flights = this.store.entities;
+  selected = this.store.selectedEntities;
+  selectedIds = this.store.selectedIds;
 
-loading = this.store.loading;
+  loading = this.store.loading;
 
-canUndo = this.store.canUndo;
-canRedo = this.store.canRedo;
+  canUndo = this.store.canUndo;
+  canRedo = this.store.canRedo;
 
-async search() {
-  this.store.load();
-}
+  async search() {
+    this.store.load();
+  }
 
-undo(): void {
-  this.store.undo();
-}
+  undo(): void {
+    this.store.undo();
+  }
 
-redo(): void {
-  this.store.redo();
-}
+  redo(): void {
+    this.store.redo();
+  }
 
-updateCriteria(from: string, to: string): void {
-  this.store.updateFilter({ from, to });
-}
+  updateCriteria(from: string, to: string): void {
+    this.store.updateFilter({ from, to });
+  }
 
-updateBasket(id: number, selected: boolean): void {
-  this.store.updateSelected(id, selected);
-}
+  updateBasket(id: number, selected: boolean): void {
+    this.store.updateSelected(id, selected);
+  }
 
 }
 ```

--- a/docs/docs/with-feature-factory.md
+++ b/docs/docs/with-feature-factory.md
@@ -128,7 +128,7 @@ define the entity type. Alongside `withEntityLoader`, there's another feature,
 Due to [certain TypeScript limitations](https://ngrx.io/guide/signals/signal-store/custom-store-features#known-typescript-issues),  
 the following code will not compile:
 
-```ts
+```typescript
 function withEntityLoader<T>() {
   return signalStoreFeature(
     type<{
@@ -172,7 +172,7 @@ signalStore(
 
 Again, `withFeatureFactory` can solve this issue by replacing the input constraint with a function parameter:
 
-```ts
+```typescript
 function withEntityLoader<T>(loader: (id: number) => Promise<T>) {
   return signalStoreFeature(
     withState({

--- a/docs/docs/with-immutable-state.md
+++ b/docs/docs/with-immutable-state.md
@@ -9,7 +9,7 @@ a runtime error.
 The protection is not limited to changes within the
 SignalStore but also outside of it.
 
-```ts
+```typescript
 const initialState = { user: { id: 1, name: 'Konrad' } };
 
 const UserStore = signalStore(
@@ -28,7 +28,7 @@ const UserStore = signalStore(
 
 If `mutateState` is called, a runtime error will be thrown.
 
-```ts
+```typescript
 class SomeComponent {
   userStore = inject(UserStore);
 
@@ -40,7 +40,7 @@ class SomeComponent {
 
 The same is also true, when `initialState` is changed:
 
-```ts
+```typescript
 initialState.user.id = 2; // 🔥 throws an error
 ```
 
@@ -48,7 +48,7 @@ Finally, it could also happen, if third-party libraries or the Angular API does 
 
 A common example is the usage in template-driven forms:
 
-```ts
+```typescript
 @Component({
   template: ` <input [(ngModel)]="userStore.user().id" /> `,
 })
@@ -61,6 +61,6 @@ By default, `withImmutableState` is only active in development mode.
 
 There is a way to enable it in production mode as well:
 
-```ts
+```typescript
 const UserStore = signalStore({ providedIn: 'root' }, withImmutableState(initialState, { enableInProduction: true }));
 ```

--- a/docs/docs/with-storage-sync.md
+++ b/docs/docs/with-storage-sync.md
@@ -10,7 +10,7 @@ As Web Storage only works in browser environments it will fallback to a stub imp
 
 Example:
 
-```ts
+```typescript
 const SyncStore = signalStore(
   withStorageSync<User>({
     key: 'synced', // key used when writing to/reading from storage
@@ -23,7 +23,7 @@ const SyncStore = signalStore(
 );
 ```
 
-```ts
+```typescript
 @Component(...)
 public class SyncedStoreComponent {
   private syncStore = inject(SyncStore);

--- a/docs/docs/with-undo-redo.md
+++ b/docs/docs/with-undo-redo.md
@@ -6,7 +6,7 @@ title: withUndoRedo()
 
 Example:
 
-```ts
+```typescript
 const SyncStore = signalStore(
   withUndoRedo({
     maxStackSize: 100, // limit of undo/redo steps - `100` by default
@@ -17,7 +17,7 @@ const SyncStore = signalStore(
 );
 ```
 
-```ts
+```typescript
 @Component(...)
 public class UndoRedoComponent {
   private syncStore = inject(SyncStore);


### PR DESCRIPTION
I looked at the docs snippet after noticing the last PR and noticed two things

- One snippet needed indents (`withDataService`)
- Some snippets didn't have a language, or were not consistent with others