### PR TITLE
fix(devtools): fix existing name error in SSR

### DIFF
--- a/libs/ngrx-toolkit/src/lib/devtools/internal/devtools-syncer.service.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/internal/devtools-syncer.service.ts
@@ -116,9 +116,9 @@ export class DevtoolsSyncer implements OnDestroy {
     const names = Object.values(this.#stores).map((store) => store.name);
 
     if (names.includes(storeName)) {
-      const { options } = throwIfNull(
-        Object.values(this.#stores).find((store) => store.name === storeName)
-      );
+      // const { options } = throwIfNull(
+      //   Object.values(this.#stores).find((store) => store.name === storeName)
+      // );
       if (!options.indexNames) {
         throw new Error(`An instance of the store ${storeName} already exists. \
 Enable automatic indexing via withDevTools('${storeName}', { indexNames: true }), or rename it upon instantiation.`);

--- a/libs/ngrx-toolkit/src/lib/devtools/tests/helpers.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/tests/helpers.spec.ts
@@ -1,4 +1,3 @@
-import { existingNames } from '../with-devtools';
 import { PLATFORM_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
@@ -34,8 +33,6 @@ export function setupExtensions(
       ],
     });
   }
-
-  existingNames.clear();
 
   return { sendSpy, connectSpy };
 }

--- a/libs/ngrx-toolkit/src/lib/devtools/with-devtools.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/with-devtools.ts
@@ -1,5 +1,5 @@
 import { signalStoreFeature, withHooks, withMethods } from '@ngrx/signals';
-import { inject } from '@angular/core';
+import { inject, InjectionToken } from '@angular/core';
 import { DevtoolsSyncer } from './internal/devtools-syncer.service';
 import {
   DevtoolsFeature,
@@ -14,10 +14,13 @@ declare global {
   }
 }
 
-export const existingNames = new Map<string, unknown>();
-
 export const renameDevtoolsMethodName = '___renameDevtoolsName';
 export const uniqueDevtoolsId = '___uniqueDevtoolsId';
+
+const EXISTING_NAMES = new InjectionToken(
+  'Array contain existing names for the signal stores',
+  { factory: () => [] as string[], providedIn: 'root' }
+);
 
 /**
  * Adds this store as a feature state to the Redux DevTools.
@@ -33,16 +36,10 @@ export const uniqueDevtoolsId = '___uniqueDevtoolsId';
  * @param features features to extend or modify the behavior of the Devtools
  */
 export function withDevtools(name: string, ...features: DevtoolsFeature[]) {
-  if (existingNames.has(name)) {
-    throw new Error(
-      `The store "${name}" has already been registered in the DevTools. Duplicate registration is not allowed.`
-    );
-  }
-  existingNames.set(name, true);
-
   return signalStoreFeature(
     withMethods(() => {
       const syncer = inject(DevtoolsSyncer);
+
       const id = syncer.getNextId();
 
       // TODO: use withProps and symbols


### PR DESCRIPTION
devtools use a static variable to store
the existing names of SignalStore classes.

In SSR, this fails because it registers
a second time in the browser and runs
see this the same name already exists.