### PR TITLE
feat: Enhanced `withDataService` to require callState collection name

### DIFF
--- a/libs/ngrx-toolkit/src/lib/with-data-service.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/with-data-service.spec.ts
@@ -383,6 +383,22 @@ describe('withDataService', () => {
     });
   }));
 
+  it('should ensure that collection name is provided in callState ', () => {
+    // @ts-expect-error should not allow `withCallState` without collection name if `withDataService` has it
+    signalStore(
+      withCallState(),
+      withEntities({
+        entity: type<Flight>(),
+        collection: 'flight',
+      }),
+      withDataService({
+        dataServiceType: MockFlightService,
+        filter: { from: 'Paris', to: 'New York' },
+        collection: 'flight',
+      })
+    );
+  });
+
   // TODO 3A: setting error state (without named collection)
   // TODO 3B: setting error state (with named collection)
 });

--- a/libs/ngrx-toolkit/src/lib/with-data-service.ts
+++ b/libs/ngrx-toolkit/src/lib/with-data-service.ts
@@ -11,19 +11,21 @@ import {
 } from '@ngrx/signals';
 import {
   CallState,
+  NamedCallStateSlice,
   getCallStateKeys,
   setError,
   setLoaded,
   setLoading,
 } from './with-call-state';
 import {
+  NamedEntityState,
   setAllEntities,
   EntityId,
   addEntity,
   updateEntity,
   removeEntity,
 } from '@ngrx/signals/entities';
-import { EntityState, NamedEntityComputed } from './shared/signal-store-models';
+import { EntityState } from './shared/signal-store-models';
 
 export type Filter = Record<string, unknown>;
 export type Entity = { id: EntityId };
@@ -201,10 +203,9 @@ export function withDataService<
   filter: F;
   collection: Collection;
 }): SignalStoreFeature<
-  // These alternatives break type inference:
-  // state: { callState: CallState } & NamedEntityState<E, Collection>,
-  // state: NamedEntityState<E, Collection>,
-  EmptyFeatureResult & { props: NamedEntityComputed<E, Collection> },
+  EmptyFeatureResult & {
+    state: NamedCallStateSlice<Collection> & NamedEntityState<E, Collection>;
+  },
   {
     state: NamedDataServiceState<E, F, Collection>;
     props: NamedDataServiceComputed<E, Collection>;


### PR DESCRIPTION
Providing collection name to `withDataService` now requires providing `withCallState` with the same collection name, otherwise type error.
This is also a small alignment with `withDataService` for signature without collection name. (if it has no collection name but `withCallState` has - type error)

Hope this PR will be useful.