### PR TITLE
docs: add `withReset` to sidenav + add imports to `withReset`

### DIFF
--- a/docs/docs/with-reset.md
+++ b/docs/docs/with-reset.md
@@ -2,6 +2,10 @@
 title: withReset()
 ---
 
+```typescript
+import { withReset } from '@angular-architects/ngrx-toolkit';
+```
+
 `withReset()` adds a method to reset the state of the Signal Store to its initial value. Nothing more to say about it 😅
 
 Example:

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -21,6 +21,7 @@ const sidebars: SidebarsConfig = {
     'with-redux',
     'with-storage-sync',
     'with-undo-redo',
+    'with-reset',
     'with-immutable-state',
     'with-feature-factory',
     'with-conditional',


### PR DESCRIPTION
I saw `withReset` was not on the sidenav

Adjacent to the imports at the top of the page PR

- I added an import like in the other PR but in this branch
- Setting this as a draft as my open question in the imports PR applies to `setResetState()`