### PR TITLE
fix(devtools): set types of `withDevtools` to `EmptyFeatureResult`

### DIFF
--- a/libs/ngrx-toolkit/src/lib/devtools/tests/types.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/tests/types.spec.ts
@@ -1,0 +1,19 @@
+import { computed } from '@angular/core';
+import { patchState, signalStore, withState } from '@ngrx/signals';
+import { withDevtools } from '../with-devtools';
+
+it('should compile when signalStore is extended from', () => {
+  class CounterStore extends signalStore(
+    { protectedState: false },
+    withState({ count: 0 }),
+    withDevtools('counter-store')
+  ) {
+    readonly myReadonlyProp = 42;
+
+    readonly doubleCount = computed(() => this.count() * 2);
+
+    increment(): void {
+      patchState(this, { count: this.count() + 1 });
+    }
+  }
+});

--- a/libs/ngrx-toolkit/src/lib/devtools/with-devtools.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/with-devtools.ts
@@ -1,4 +1,10 @@
-import { signalStoreFeature, withHooks, withMethods } from '@ngrx/signals';
+import {
+  EmptyFeatureResult,
+  SignalStoreFeature,
+  signalStoreFeature,
+  withHooks,
+  withMethods,
+} from '@ngrx/signals';
 import { inject, InjectionToken } from '@angular/core';
 import { DevtoolsSyncer } from './internal/devtools-syncer.service';
 import {
@@ -71,5 +77,5 @@ export function withDevtools(name: string, ...features: DevtoolsFeature[]) {
         },
       };
     })
-  );
+  ) as SignalStoreFeature<EmptyFeatureResult, EmptyFeatureResult>;
 }


### PR DESCRIPTION
This fixes an issue with SignalStore's used to extend from, where `withDevtools` messed up the typing.

Closes: #164, #165