### PR TITLE
docs: deprecate `withRedux`

### DIFF
--- a/docs/docs/extensions.md
+++ b/docs/docs/extensions.md
@@ -10,7 +10,7 @@ It offers extensions like:
 - [Conditional Features](./with-conditional): Allows adding features to the store conditionally
 - [DataService](./with-data-service): Builds on top of `withEntities` and adds the backend synchronization to it
 - [Immutable State Protection](./with-immutable-state): Protects the state from being mutated outside or inside the Store.
-- [Redux](./with-redux): Possibility to use the Redux Pattern (Reducer, Actions, Effects)
+- [~Redux~](./with-redux): Possibility to use the Redux Pattern. Deprecated in favor of NgRx's `@ngrx/signals/events` starting in 19.2
 - [Reset](./with-reset): Adds a `resetState` method to your store
 - [Call State](./with-call-state): Add call state management to your signal stores
 - [Storage Sync](./with-storage-sync): Synchronizes the Store with Web Storage

--- a/docs/docs/with-redux.md
+++ b/docs/docs/with-redux.md
@@ -3,17 +3,22 @@ title: withRedux()
 ---
 
 ```typescript
+// DEPRECATED
 import { withRedux } from '@angular-architects/ngrx-toolkit';
+
+// Use `@ngrx/signals/events` instead
 ```
 
 `withRedux()` brings back the Redux pattern into the Signal Store.
 
 It can be combined with any other extension of the Signal Store.
 
-:::note
-Please note, that there is an [official RFC](https://github.com/ngrx/platform/issues/4580) that a Redux extension will be added to the SignalStore in the future.
+:::warning
+## Deprecation
 
-If you use `withRedux`, you will probably need to refactor your store when the official Redux extension is released.
+Please note, `@ngrx/signals/events` [was released as experimental in `@ngrx/signals/` v19.2](https://dev.to/ngrx/announcing-events-plugin-for-ngrx-signalstore-a-modern-take-on-flux-architecture-4dhn).
+
+If you use `withRedux`, you should transition to using the official `@ngrx/signals/events` features.
 :::
 
 There is also a [Redux Connector](./create-redux-state) available, which is a separate package and has a dependency to `@ngrx/store`.

--- a/libs/ngrx-toolkit/src/lib/with-redux.ts
+++ b/libs/ngrx-toolkit/src/lib/with-redux.ts
@@ -134,6 +134,8 @@ type EffectsFactory<StateActionFns extends ActionFns> = (
 ) => Record<string, Observable<unknown>>;
 
 /**
+ * @deprecated Use NgRx's `@ngrx/signals/events` starting in 19.2
+ * 
  * Creates the effects function to separate the effects logic into another file.
  *
  * ```typescript


### PR DESCRIPTION
NgRx introduced events in 19.2: https://dev.to/ngrx/announcing-events-plugin-for-ngrx-signalstore-a-modern-take-on-flux-architecture-4dhn. Support for `withRedux` in the toolkit is marked as deprecated with this change.