### PR TITLE
chore: export /lib/mutation/mutation at index.ts

### DIFF
--- a/libs/ngrx-toolkit/src/index.ts
+++ b/libs/ngrx-toolkit/src/index.ts
@@ -55,3 +55,5 @@ export {
 
 export * from './lib/mutation/http-mutation';
 export { rxMutation } from './lib/mutation/rx-mutation';
+
+export * from './lib/mutation/mutation';


### PR DESCRIPTION
- Affected version:
@angular-architects/ngrx-toolkit@20.4.1

- Problem:
```powershell
error TS4023: Exported variable 'MyOwnStoreInLib' has or is using name 'Mutation' from external module 

"C:/..../node_modules/@angular-architects/ngrx-toolkit/index" but cannot be named.
```

- Fix:
Apply export for ./lib/mutation/mutation (.ts) file.