### PR TITLE
docs: use non-expiring Discord invite

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -100,7 +100,7 @@ const config: Config = {
           position: 'right',
         },
         {
-          href: 'https://discord.gg/Q3bQSX8C',
+          href: 'https://discord.gg/xnkSWDmpXZ',
           label: 'Discord',
           position: 'right',
         },


### PR DESCRIPTION
@wolfmanfx oops, I made the PR in my personal repo. Tagging you here as well to formally be consistent in either version.