### PR TITLE
docs: mention `hasValue` issue disclaimers

### DIFF
--- a/docs/docs/mutations.md
+++ b/docs/docs/mutations.md
@@ -34,7 +34,7 @@ This guide covers
   - State signals available (`value/status/error/isPending`)
       <!-- TODO - resolve when #235 closed-->
     - For `httpMutation`, the response type is specified with the param `parse: (res: T) => res as T`
-    - `hasValue` signal to narrow type. NOTE: currently there is an outstanding bug that this does not properly narrow.
+    - `hasValue` signal to narrow type. ⚠️NOTE⚠️: currently there is an [outstanding bug](https://github.com/angular-architects/ngrx-toolkit/issues/235) that this does not properly narrow.
   - [How to use](#usage-withmutations-or-solo-functions), as:
     - _standalone functions_
     - In `withMutations` store _feature_

--- a/docs/docs/with-entity-resources.md
+++ b/docs/docs/with-entity-resources.md
@@ -6,6 +6,8 @@ title: withEntityResources()
 import { withEntityResources } from '@angular-architects/ngrx-toolkit';
 ```
 
+> **⚠️ Important Note**: We have found some issues with `hasValue()` not narrowing correctly. If you have any insights or want to follow developments, please refer to our issue: ["bug(withResource and Mutations): hasValue() does not narrow the respective value signal #235"](https://github.com/angular-architects/ngrx-toolkit/issues/235)
+
 `withEntityResources()` integrates Angular Resources that return arrays into NgRx SignalStore using the Entity helpers from `@ngrx/signals/entities`.
 
 > Note: This feature builds on [withResource()](./with-resource.md) and adds an entity view over array resources.

--- a/docs/docs/with-resource.md
+++ b/docs/docs/with-resource.md
@@ -8,6 +8,8 @@ import { withResource } from '@angular-architects/ngrx-toolkit';
 
 > **⚠️ Important Note**: This extension is very likely to land in NgRx once Angular's `Resource` enters developer preview. The `withResource` extension provides early access to this functionality and will be maintained for compatibility until the official NgRx implementation is available.
 
+> **⚠️ Important Note**: We have found some issues with `hasValue()` not narrowing correctly. If you have any insights or want to follow developments, please refer to our issue: ["bug(withResource and Mutations): hasValue() does not narrow the respective value signal #235"](https://github.com/angular-architects/ngrx-toolkit/issues/235)
+
 `withResource()` is a feature in NgRx SignalStore that connects Angular's Resource API with the store.
 The idea: you can use a store to directly manage async data (like loading from an API), and `withResource()` helps you wire that in.
 


### PR DESCRIPTION
This has been a tricky issue that has gone on long enough that I figured we aught to be upfront in any related documentation. 

https://github.com/angular-architects/ngrx-toolkit/issues/235