### PR TITLE
docs: document mutations `params` argument

### DIFF
--- a/docs/docs/mutations.md
+++ b/docs/docs/mutations.md
@@ -147,7 +147,7 @@ In the mutation: _optional_ `onSuccess` and `onError` callbacks.
 
 The callbacks are called with two parameters:
 
-1. The result of the mutation (onSuccess) or the error (onError)
+1. The result of the mutation (`onSuccess`) or the error (`onError`)
 2. The parameter passed when calling the mutation
 
 ```ts


### PR DESCRIPTION
I could not see any documentation regarding the 2nd parameter to the callbacks. 

I tried it out and it worked but it would be good for it to be documented. Not sure if the examples need to fit to a specific pattern.