### PR TITLE
fix(devtools): hide symbol `DEVTOOL_FEATURE_NAMES` [backport v20, v21]

### DIFF
--- a/libs/ngrx-toolkit/src/lib/devtools/with-dev-tools-stub.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/with-dev-tools-stub.ts
@@ -6,7 +6,10 @@ import { DEVTOOL_FEATURE_NAMES, withDevtools } from './with-devtools';
  */
 export const withDevToolsStub: typeof withDevtools = () =>
   signalStoreFeature(
-    withProps(() => ({
-      [DEVTOOL_FEATURE_NAMES]: [GLITCH_TRACKING_FEATURE],
-    })),
+    withProps(
+      () =>
+        ({
+          [DEVTOOL_FEATURE_NAMES]: [GLITCH_TRACKING_FEATURE],
+        }) as Record<string, never>,
+    ),
   );

--- a/libs/ngrx-toolkit/src/lib/devtools/with-devtools.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/with-devtools.ts
@@ -80,8 +80,5 @@ export function withDevtools(name: string, ...features: DevtoolsFeature[]) {
         },
       };
     }),
-  ) as SignalStoreFeature<
-    EmptyFeatureResult,
-    EmptyFeatureResult & { props: { [DEVTOOL_FEATURE_NAMES]: string[] } }
-  >;
+  ) as SignalStoreFeature<EmptyFeatureResult, EmptyFeatureResult>;
 }


### PR DESCRIPTION
Closes #279