### PR TITLE
docs(`withResource`): mention how to patch resource state

### DIFF
--- a/docs/docs/with-resource.md
+++ b/docs/docs/with-resource.md
@@ -132,7 +132,7 @@ Options:
 Under the hood, `'previous value'` and `'undefined value'` proxy the value. For a detailed explanation for why this is done, check out the [JSDoc for the error handling strategy](https://github.com/angular-architects/ngrx-toolkit/blob/main/libs/ngrx-toolkit/src/lib/with-resource.ts#L402).
 
 The implications of `undefined value` is that the inferred value can be `undefined`, even if there is a `defaultValue` set for the resource.
-For example, in the [`Updating`](#updating) section, `listValue` will be inferred as `User[] | undefined`. To be able to infer the type with a gauranteed value,
+For example, in the [`Updating`](#updating) section, `listValue` will be inferred as `User[] | undefined`. To be able to infer the type with a guaranteed value,
 use `{ errorHandling: 'previous value' }` of `withResource` in conjunction with `defaultValue` of said resource.
 
 ## Component Usage

--- a/docs/docs/with-resource.md
+++ b/docs/docs/with-resource.md
@@ -83,6 +83,25 @@ With named resources, each resource gets prefixed properties:
 - **Single resource:** use when your store works with just one data source.
 - **Named resources:** use when your store is larger and manages multiple entities or async operations.
 
+## Updating
+
+The state to patch corresponds directly to the name of the resource's value signal.
+
+```ts
+const UserStore = signalStore(
+  withResource((state) => httpResource<User>(() => `/user/${state.userId}`)),
+  withResource(({ userId }) => ({
+    list: httpResource<User[]>(() => '/users', { defaultValue: [] }),
+  })),
+);
+
+// Unnamed resource: `value`
+patchState(store, { value: undefined });
+
+// Named resource: name prefix + `Value`
+patchState(store, { listValue: [] });
+```
+
 ## Error Handling
 
 The error throwing behavior of the native `resource` causes a deadlock in the error case.

--- a/docs/docs/with-resource.md
+++ b/docs/docs/with-resource.md
@@ -99,6 +99,7 @@ const UserStore = signalStore(
 patchState(store, { value: { id: 1, name: 'John' } });
 
 // Named resource: name prefix + `Value`
+// See the "Error Handling" section about why `listValue` has to be treated like it could be undefined.
 patchState(store, ({ listValue }) => ({ listValue: [...(listValue ?? []), { id: 1, name: 'John' }] }));
 ```
 
@@ -129,6 +130,10 @@ Options:
 1. `'native'`. No special handling is provided, inline with default error behavior.
 
 Under the hood, `'previous value'` and `'undefined value'` proxy the value. For a detailed explanation for why this is done, check out the [JSDoc for the error handling strategy](https://github.com/angular-architects/ngrx-toolkit/blob/main/libs/ngrx-toolkit/src/lib/with-resource.ts#L402).
+
+The implications of `undefined value` is that the inferred value can be `undefined`, even if there is a `defaultValue` set for the resource.
+For example, in the [`Updating`](#updating) section, `listValue` will be inferred as `User[] | undefined`. To be able to infer the type with a gauranteed value,
+use `{ errorHandling: 'previous value' }` of `withResource` in conjunction with `defaultValue` of said resource.
 
 ## Component Usage
 

--- a/docs/docs/with-resource.md
+++ b/docs/docs/with-resource.md
@@ -96,10 +96,10 @@ const UserStore = signalStore(
 );
 
 // Unnamed resource: `value`
-patchState(store, { value: undefined });
+patchState(store, { value: { id: 1, name: 'John' } });
 
 // Named resource: name prefix + `Value`
-patchState(store, { listValue: [] });
+patchState(store, ({ listValue }) => ({ listValue: [...(listValue ?? []), { id: 1, name: 'John' }] }));
 ```
 
 ## Error Handling


### PR DESCRIPTION
Wondered how, imagined this was how, and saw that the JSDoc mentions this. But no doc mention until now.

Closes #281