### PR TITLE
fix: assign properties of mutations in `withMutation`

### DIFF
--- a/libs/ngrx-toolkit/src/lib/with-mutations.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/with-mutations.spec.ts
@@ -116,6 +116,31 @@ function createTestSetup(flatteningOperator = concatOp) {
 }
 
 describe('withMutations with rxMutation', () => {
+  // fix: assign properties of mutations in withMutation https://github.com/angular-architects/ngrx-toolkit/pull/288
+  it("does not lose the runtime properties of a mutation's direct reference when assigning it to a component field", fakeAsync(() => {
+    const testSetup = createTestSetup();
+    const store = testSetup.store;
+
+    // Simulates `readonly myMutation = this.store.increment` in a component.
+    const myMutation = store.increment;
+
+    expect(myMutation.status()).toEqual('idle');
+    expect(typeof myMutation.isPending).toEqual('function');
+    expect(myMutation.isPending()).toEqual(false);
+
+    myMutation(2);
+    expect(myMutation.status()).toEqual('pending');
+    expect(myMutation.isPending()).toEqual(true);
+
+    tick(2000);
+
+    expect(myMutation.status()).toEqual('success');
+    expect(myMutation.isPending()).toEqual(false);
+    expect(myMutation.error()).toEqual(undefined);
+
+    expect(store.counter()).toEqual(7);
+  }));
+
   it('should update the state', fakeAsync(() => {
     const testSetup = createTestSetup();
     const store = testSetup.store;

--- a/libs/ngrx-toolkit/src/lib/with-mutations.ts
+++ b/libs/ngrx-toolkit/src/lib/with-mutations.ts
@@ -118,14 +118,25 @@ function createMutationsFeature<Result extends MutationsDictionary>(
       keys.reduce(
         (acc, key) => ({
           ...acc,
-          [key]: async (params: never) => {
-            const mutation = mutations[key];
-            if (!mutation) {
-              throw new Error(`Mutation ${key} not found`);
-            }
-            const result = await mutation(params);
-            return result;
-          },
+          [key]: Object.assign(
+            async (params: never) => {
+              const mutation = mutations[key];
+              if (!mutation) {
+                throw new Error(`Mutation ${key} not found`);
+              }
+              const result = await mutation(params);
+
+              return result;
+            },
+            {
+              status: mutations[key].status,
+              value: mutations[key].value,
+              isPending: mutations[key].isPending,
+              isSuccess: mutations[key].isSuccess,
+              error: mutations[key].error,
+              hasValue: mutations[key].hasValue,
+            },
+          ),
         }),
         {} as MethodsDictionary,
       ),

--- a/libs/ngrx-toolkit/src/lib/with-mutations.ts
+++ b/libs/ngrx-toolkit/src/lib/with-mutations.ts
@@ -118,25 +118,18 @@ function createMutationsFeature<Result extends MutationsDictionary>(
       keys.reduce(
         (acc, key) => ({
           ...acc,
-          [key]: Object.assign(
-            async (params: never) => {
-              const mutation = mutations[key];
-              if (!mutation) {
-                throw new Error(`Mutation ${key} not found`);
-              }
+          [key]: (() => {
+            const mutation = mutations[key];
+            if (!mutation) {
+              throw new Error(`Mutation ${key} not found`);
+            }
+
+            return Object.assign(async (params: never) => {
               const result = await mutation(params);
 
               return result;
-            },
-            {
-              status: mutations[key].status,
-              value: mutations[key].value,
-              isPending: mutations[key].isPending,
-              isSuccess: mutations[key].isSuccess,
-              error: mutations[key].error,
-              hasValue: mutations[key].hasValue,
-            },
-          ),
+            }, mutation);
+          })(),
         }),
         {} as MethodsDictionary,
       ),


### PR DESCRIPTION
## Description

Would fix #286

Would fix the following:

```ts
// component
readonly myMutation = this.store.myMutation; // Mutation<number, any>

// html
{{ myMutation.isPending() }}

// runtime error:
ERROR TypeError: ctx.myMutation.isPending is not a function
```

`Object.assign` will explicitly copy the properties of the mutation so that they are all available

## Outstanding before going out of Draft

Tests pending