### PR TITLE
feat(devtools): expose tracked event payloads from withTrackedReducer

### DIFF
--- a/apps/demo/src/app/feature-factory/feature-factory.component.ts
+++ b/apps/demo/src/app/feature-factory/feature-factory.component.ts
@@ -34,7 +34,7 @@ function withMyEntity<Entity>(loadMethod: (id: number) => Promise<Entity>) {
 const UserStore = signalStore(
   { providedIn: 'root' },
   withMethods(() => ({
-    findById(id: number) {
+    findById(_id: number) {
       return of({ id: 1, name: 'Konrad' });
     },
   })),

--- a/docs/docs/with-devtools.md
+++ b/docs/docs/with-devtools.md
@@ -41,7 +41,7 @@ The extensions don't activate during app initialization (as it is with `@ngrx/st
 import { updateState } from '@angular-architects/ngrx-toolkit';
 ```
 
-The Signal Store does not use the Redux pattern, so there are no action names involved by default. Instead, every action is referred to as a "Store Update". If you want to customize the action name for better clarity, you can use the `updateState()` function instead of `patchState()`:
+The Signal Store does not use the Redux pattern, so there are no action names involved by default. Instead, every action is referred to as a "Store Update". If you want to customize the action entry for better clarity, you can use the `updateState()` function instead of `patchState()`:
 
 ```typescript
 import { updateState } from '@angular-architects/ngrx-toolkit';
@@ -50,6 +50,9 @@ patchState(this.store, { loading: false });
 
 // updateState is a wrapper around patchState and has an action name as second parameter
 updateState(this.store, 'update loading', { loading: false });
+
+// updateState also accepts an action object with a mandatory type field
+updateState(this.store, { type: '[Book Store] bookSelected', payload: { bookId: '1' } }, { selectedBookId: '1' });
 ```
 
 ## `renameDevtoolsName()`
@@ -172,7 +175,7 @@ const Store = signalStore(
 ## Events tracking: `withTrackedReducer`
 
 `withTrackedReducer` tracks state changes within the events
-plugin. This utility automatically derives the event name, streamlining
+plugin. This utility automatically derives the event entry, streamlining
 the tracking process.
 
 To use it
@@ -188,6 +191,7 @@ export const bookEvents = eventGroup({
   source: 'Book Store',
   events: {
     loadBooks: type<void>(),
+    bookSelected: type<{ bookId: string }>(),
   },
 });
 
@@ -201,6 +205,10 @@ const Store = signalStore(
     // `[Book Store] loadBooks` will show up in the devtools
     on(bookEvents.loadBooks, () => ({
       books: mockBooks,
+    })),
+    // DevTools action will include payload: { bookId: string }
+    on(bookEvents.bookSelected, ({ payload }) => ({
+      selectedBookId: payload.bookId,
     })),
   ),
   withHooks({

--- a/docs/docs/with-devtools.md
+++ b/docs/docs/with-devtools.md
@@ -41,7 +41,7 @@ The extensions don't activate during app initialization (as it is with `@ngrx/st
 import { updateState } from '@angular-architects/ngrx-toolkit';
 ```
 
-The Signal Store does not use the Redux pattern, so there are no action names involved by default. Instead, every action is referred to as a "Store Update". If you want to customize the action entry for better clarity, you can use the `updateState()` function instead of `patchState()`:
+The Signal Store does not use the Redux pattern, so there are no action names involved by default. Instead, every action is referred to as a "Store Update". If you want to customize the action name for better clarity, you can use the `updateState()` function instead of `patchState()`:
 
 ```typescript
 import { updateState } from '@angular-architects/ngrx-toolkit';
@@ -50,9 +50,6 @@ patchState(this.store, { loading: false });
 
 // updateState is a wrapper around patchState and has an action name as second parameter
 updateState(this.store, 'update loading', { loading: false });
-
-// updateState also accepts an action object with a mandatory type field
-updateState(this.store, { type: '[Book Store] bookSelected', payload: { bookId: '1' } }, { selectedBookId: '1' });
 ```
 
 ## `renameDevtoolsName()`
@@ -175,7 +172,7 @@ const Store = signalStore(
 ## Events tracking: `withTrackedReducer`
 
 `withTrackedReducer` tracks state changes within the events
-plugin. This utility automatically derives the event entry, streamlining
+plugin. This utility automatically derives the event name, streamlining
 the tracking process.
 
 To use it

--- a/libs/ngrx-toolkit/src/lib/devtools/internal/current-action-names.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/internal/current-action-names.ts
@@ -1,1 +1,3 @@
-export const currentActionNames = new Set<string>();
+import { Action } from './models';
+
+export const currentActionNames = new Set<string | Action>();

--- a/libs/ngrx-toolkit/src/lib/devtools/internal/devtools-syncer.service.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/internal/devtools-syncer.service.ts
@@ -18,7 +18,7 @@ const dummyConnection: Connection = {
 
 function toDevtoolsAction(actions: (string | Action)[]): Action {
   if (!actions.length) {
-    return { type: 'Store Update' };
+    return { type: 'Store Update' } as Action;
   }
 
   const objects = actions.filter((a): a is Action => typeof a === 'object');
@@ -26,7 +26,9 @@ function toDevtoolsAction(actions: (string | Action)[]): Action {
     ...new Set(actions.map((a) => (typeof a === 'string' ? a : a.type))),
   ].join(', ');
 
-  return objects.length ? { ...objects[0], type } : { type };
+  return objects.length
+    ? ({ ...objects[0], type } as Action)
+    : ({ type } as Action);
 }
 
 /**

--- a/libs/ngrx-toolkit/src/lib/devtools/internal/devtools-syncer.service.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/internal/devtools-syncer.service.ts
@@ -10,11 +10,24 @@ import { StateSource } from '@ngrx/signals';
 import { REDUX_DEVTOOLS_CONFIG } from '../provide-devtools-config';
 import { currentActionNames } from './current-action-names';
 import { DevtoolsInnerOptions } from './devtools-feature';
-import { Connection, StoreRegistry, Tracker } from './models';
+import { Action, Connection, StoreRegistry, Tracker } from './models';
 
 const dummyConnection: Connection = {
   send: () => void true,
 };
+
+function toDevtoolsAction(actions: (string | Action)[]): Action {
+  if (!actions.length) {
+    return { type: 'Store Update' };
+  }
+
+  const objects = actions.filter((a): a is Action => typeof a === 'object');
+  const type = [
+    ...new Set(actions.map((a) => (typeof a === 'string' ? a : a.type))),
+  ].join(', ');
+
+  return objects.length ? { ...objects[0], type } : { type };
+}
 
 /**
  * A service provided by the root injector is
@@ -90,11 +103,11 @@ export class DevtoolsSyncer implements OnDestroy {
       ...mappedChangedStatePerName,
     };
 
-    const names = Array.from(currentActionNames);
-    const type = names.length ? names.join(', ') : 'Store Update';
+    const actions = Array.from(currentActionNames);
+    const action = toDevtoolsAction(actions);
     currentActionNames.clear();
 
-    this.#connection.send({ type }, this.#currentState);
+    this.#connection.send(action, this.#currentState);
   }
 
   getNextId() {

--- a/libs/ngrx-toolkit/src/lib/devtools/internal/models.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/internal/models.ts
@@ -2,7 +2,7 @@ import { StateSource } from '@ngrx/signals';
 import { ReduxDevtoolsConfig } from '../provide-devtools-config';
 import { DevtoolsInnerOptions } from './devtools-feature';
 
-export type Action = { type: string };
+export type Action = { type: string; [key: string]: unknown };
 export type Connection = {
   send: (action: Action, state: Record<string, unknown>) => void;
 };

--- a/libs/ngrx-toolkit/src/lib/devtools/internal/models.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/internal/models.ts
@@ -2,7 +2,10 @@ import { StateSource } from '@ngrx/signals';
 import { ReduxDevtoolsConfig } from '../provide-devtools-config';
 import { DevtoolsInnerOptions } from './devtools-feature';
 
-export type Action = { type: string; [key: string]: unknown };
+declare const __actionBrand: unique symbol;
+export type Action = { type: string; [key: string]: unknown } & {
+  readonly [__actionBrand]: true;
+};
 export type Connection = {
   send: (action: Action, state: Record<string, unknown>) => void;
 };

--- a/libs/ngrx-toolkit/src/lib/devtools/tests/action-name.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/tests/action-name.spec.ts
@@ -45,29 +45,4 @@ describe('updateState', () => {
       { shop: { name: 'i4' } },
     );
   });
-
-  it('should set and send an action object', () => {
-    const { sendSpy } = setupExtensions();
-
-    const Store = signalStore(
-      { providedIn: 'root' },
-      withDevtools('shop'),
-      withState({ name: 'Car' }),
-      withMethods((store) => ({
-        setName(name: string) {
-          updateState(store, { type: 'Set Name', name }, { name });
-        },
-      })),
-    );
-    const store = TestBed.inject(Store);
-    TestBed.flushEffects();
-
-    store.setName('i4');
-    TestBed.flushEffects();
-
-    expect(sendSpy).toHaveBeenLastCalledWith(
-      { type: 'Set Name', name: 'i4' },
-      { shop: { name: 'i4' } },
-    );
-  });
 });

--- a/libs/ngrx-toolkit/src/lib/devtools/tests/action-name.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/tests/action-name.spec.ts
@@ -45,4 +45,29 @@ describe('updateState', () => {
       { shop: { name: 'i4' } },
     );
   });
+
+  it('should set and send an action object', () => {
+    const { sendSpy } = setupExtensions();
+
+    const Store = signalStore(
+      { providedIn: 'root' },
+      withDevtools('shop'),
+      withState({ name: 'Car' }),
+      withMethods((store) => ({
+        setName(name: string) {
+          updateState(store, { type: 'Set Name', name }, { name });
+        },
+      })),
+    );
+    const store = TestBed.inject(Store);
+    TestBed.flushEffects();
+
+    store.setName('i4');
+    TestBed.flushEffects();
+
+    expect(sendSpy).toHaveBeenLastCalledWith(
+      { type: 'Set Name', name: 'i4' },
+      { shop: { name: 'i4' } },
+    );
+  });
 });

--- a/libs/ngrx-toolkit/src/lib/devtools/tests/action-name.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/tests/action-name.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { signalStore, withMethods, withState } from '@ngrx/signals';
-import { updateState } from '../update-state';
+import { asAction, updateState } from '../update-state';
 import { withDevtools } from '../with-devtools';
 import { setupExtensions } from './helpers.spec';
 
@@ -42,6 +42,31 @@ describe('updateState', () => {
 
     expect(sendSpy).toHaveBeenLastCalledWith(
       { type: 'Set Name' },
+      { shop: { name: 'i4' } },
+    );
+  });
+
+  it('should set and send an action object', () => {
+    const { sendSpy } = setupExtensions();
+
+    const Store = signalStore(
+      { providedIn: 'root' },
+      withDevtools('shop'),
+      withState({ name: 'Car' }),
+      withMethods((store) => ({
+        setName(name: string) {
+          updateState(store, asAction({ type: 'Set Name', name }), { name });
+        },
+      })),
+    );
+    const store = TestBed.inject(Store);
+    TestBed.flushEffects();
+
+    store.setName('i4');
+    TestBed.flushEffects();
+
+    expect(sendSpy).toHaveBeenLastCalledWith(
+      { type: 'Set Name', name: 'i4' },
       { shop: { name: 'i4' } },
     );
   });

--- a/libs/ngrx-toolkit/src/lib/devtools/tests/with-tracked-reducer.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/tests/with-tracked-reducer.spec.ts
@@ -28,6 +28,7 @@ const testEvents = eventGroup({
   source: 'Spec Store',
   events: {
     bump: type<void>(),
+    bookSelected: type<{ bookId: string }>(),
   },
 });
 
@@ -76,6 +77,29 @@ describe('withTrackedReducer', () => {
     expect(sendSpy).toHaveBeenLastCalledWith(
       { type: '[Spec Store] bump' },
       { 'store-a': { count: 1 }, 'store-b': { count: 1 } },
+    );
+  });
+
+  it('should send event payload to devtools when using tracked reducer', () => {
+    const { sendSpy, withBasicStore } = setup();
+
+    const Store = signalStore(
+      { providedIn: 'root' },
+      withBasicStore('store'),
+      withTrackedReducer(
+        on(testEvents.bookSelected, ({ payload }) => ({
+          count: Number(payload.bookId),
+        })),
+      ),
+    );
+
+    TestBed.inject(Store);
+
+    dispatchBookSelectedEvent('42');
+
+    expect(sendSpy).toHaveBeenLastCalledWith(
+      { type: '[Spec Store] bookSelected', payload: { bookId: '42' } },
+      { store: { count: 42 } },
     );
   });
 
@@ -258,6 +282,10 @@ describe('withTrackedReducer', () => {
 
 function dispatchBumpEvent() {
   TestBed.inject(Dispatcher).dispatch(testEvents.bump());
+}
+
+function dispatchBookSelectedEvent(bookId: string) {
+  TestBed.inject(Dispatcher).dispatch(testEvents.bookSelected({ bookId }));
 }
 
 function setup() {

--- a/libs/ngrx-toolkit/src/lib/devtools/update-state.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/update-state.ts
@@ -4,7 +4,6 @@ import {
   WritableStateSource,
 } from '@ngrx/signals';
 import { currentActionNames } from './internal/current-action-names';
-import { Action } from './internal/models';
 
 type PatchFn = typeof originalPatchState extends (
   arg1: infer First,
@@ -29,7 +28,7 @@ export const patchState: PatchFn = (state, action, ...rest) => {
  */
 export function updateState<State extends object>(
   stateSource: WritableStateSource<State>,
-  action: string | Action,
+  action: string,
   ...updaters: Array<
     Partial<NoInfer<State>> | PartialStateUpdater<NoInfer<State>>
   >

--- a/libs/ngrx-toolkit/src/lib/devtools/update-state.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/update-state.ts
@@ -4,6 +4,7 @@ import {
   WritableStateSource,
 } from '@ngrx/signals';
 import { currentActionNames } from './internal/current-action-names';
+import { Action } from './internal/models';
 
 type PatchFn = typeof originalPatchState extends (
   arg1: infer First,
@@ -28,7 +29,7 @@ export const patchState: PatchFn = (state, action, ...rest) => {
  */
 export function updateState<State extends object>(
   stateSource: WritableStateSource<State>,
-  action: string,
+  action: string | Action,
   ...updaters: Array<
     Partial<NoInfer<State>> | PartialStateUpdater<NoInfer<State>>
   >

--- a/libs/ngrx-toolkit/src/lib/devtools/update-state.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/update-state.ts
@@ -4,6 +4,7 @@ import {
   WritableStateSource,
 } from '@ngrx/signals';
 import { currentActionNames } from './internal/current-action-names';
+import { Action } from './internal/models';
 
 type PatchFn = typeof originalPatchState extends (
   arg1: infer First,
@@ -20,6 +21,14 @@ export const patchState: PatchFn = (state, action, ...rest) => {
 };
 
 /**
+ * Casts an object with a `type` property to an {@link Action}.
+ * Use this when you need to pass a structured action object to {@link updateState}.
+ */
+export function asAction<T extends { type: string }>(value: T): Action {
+  return value as unknown as Action;
+}
+
+/**
  * Wrapper of `patchState` for DevTools integration. Next to updating the state,
  * it also sends the action to the DevTools.
  * @param stateSource state of Signal Store
@@ -28,7 +37,7 @@ export const patchState: PatchFn = (state, action, ...rest) => {
  */
 export function updateState<State extends object>(
   stateSource: WritableStateSource<State>,
-  action: string,
+  action: string | Action,
   ...updaters: Array<
     Partial<NoInfer<State>> | PartialStateUpdater<NoInfer<State>>
   >

--- a/libs/ngrx-toolkit/src/lib/devtools/with-tracked-reducer.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/with-tracked-reducer.ts
@@ -3,7 +3,6 @@ import {
   EmptyFeatureResult,
   getState,
   PartialStateUpdater,
-  patchState,
   SignalStoreFeature,
   signalStoreFeature,
   type,
@@ -16,7 +15,7 @@ import {
 } from '@ngrx/signals/events';
 import { tap } from 'rxjs/operators';
 import { GLITCH_TRACKING_FEATURE } from './features/with-glitch-tracking';
-import { currentActionNames } from './internal/current-action-names';
+import { updateState, asAction } from './update-state';
 import { DEVTOOL_FEATURE_NAMES } from './with-devtools';
 
 export function withTrackedReducer<State extends object>(
@@ -40,8 +39,7 @@ export function withTrackedReducer<State extends object>(
             const result = caseReducer.reducer(event, state);
             const updaters = Array.isArray(result) ? result : [result];
 
-            currentActionNames.add(event);
-            patchState(store, ...updaters);
+            updateState(store, asAction(event), ...updaters);
           }),
         ),
       ),

--- a/libs/ngrx-toolkit/src/lib/devtools/with-tracked-reducer.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/with-tracked-reducer.ts
@@ -39,7 +39,7 @@ export function withTrackedReducer<State extends object>(
             const result = caseReducer.reducer(event, state);
             const updaters = Array.isArray(result) ? result : [result];
 
-            updateState(store, event.type, ...updaters);
+            updateState(store, event, ...updaters);
           }),
         ),
       ),

--- a/libs/ngrx-toolkit/src/lib/devtools/with-tracked-reducer.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/with-tracked-reducer.ts
@@ -3,6 +3,7 @@ import {
   EmptyFeatureResult,
   getState,
   PartialStateUpdater,
+  patchState,
   SignalStoreFeature,
   signalStoreFeature,
   type,
@@ -15,7 +16,7 @@ import {
 } from '@ngrx/signals/events';
 import { tap } from 'rxjs/operators';
 import { GLITCH_TRACKING_FEATURE } from './features/with-glitch-tracking';
-import { updateState } from './update-state';
+import { currentActionNames } from './internal/current-action-names';
 import { DEVTOOL_FEATURE_NAMES } from './with-devtools';
 
 export function withTrackedReducer<State extends object>(
@@ -39,7 +40,8 @@ export function withTrackedReducer<State extends object>(
             const result = caseReducer.reducer(event, state);
             const updaters = Array.isArray(result) ? result : [result];
 
-            updateState(store, event, ...updaters);
+            currentActionNames.add(event);
+            patchState(store, ...updaters);
           }),
         ),
       ),


### PR DESCRIPTION
`withTrackedReducer` now forwards full event objects to updateState so Redux DevTools can show payload data, not only action names.

Closes https://github.com/angular-architects/ngrx-toolkit/issues/294