### PR TITLE
feat(devtools): create tracked event and tracked event group using proxy

### DIFF
--- a/libs/ngrx-toolkit/src/index.ts
+++ b/libs/ngrx-toolkit/src/index.ts
@@ -6,11 +6,12 @@ export {
   provideDevtoolsConfig,
 } from './lib/devtools/provide-devtools-config';
 export { renameDevtoolsName } from './lib/devtools/rename-devtools-name';
+export { trackedEvent } from './lib/devtools/tracked-event';
+export { trackedEventGroup } from './lib/devtools/tracked-event-group';
 export { patchState, updateState } from './lib/devtools/update-state';
 export { withDevToolsStub } from './lib/devtools/with-dev-tools-stub';
 export { DevtoolsFeature, withDevtools } from './lib/devtools/with-devtools';
 export { withTrackedReducer } from './lib/devtools/with-tracked-reducer';
-
 export {
   createEffects,
   createReducer,

--- a/libs/ngrx-toolkit/src/lib/devtools/tracked-event-group.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/tracked-event-group.ts
@@ -1,0 +1,45 @@
+import { EventCreator, eventGroup } from '@ngrx/signals/events';
+import { Prettify } from '../shared/prettify';
+import { currentActionNames } from './internal/current-action-names';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type EventType<
+  Source extends string,
+  EventName extends string,
+> = `[${Source}] ${EventName}`;
+
+type EventCreatorGroup<
+  Source extends string,
+  Events extends Record<string, any>,
+> = {
+  readonly [EventName in keyof Events]: EventName extends string
+    ? EventCreator<EventType<Source, EventName>, Events[EventName]>
+    : never;
+};
+export function trackedEventGroup<
+  Source extends string,
+  Events extends Record<string, unknown>,
+>(config: {
+  source: Source;
+  events: Events;
+}): Prettify<EventCreatorGroup<Source, Events>> {
+  const group = eventGroup(config);
+
+  return new Proxy<Prettify<EventCreatorGroup<Source, Events>>>(group, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+
+      if (typeof value === 'function') {
+        const returnFunc = (...args: unknown[]) => {
+          const type = value.type as string;
+          currentActionNames.add(type);
+          return (value as any)(...args);
+        };
+        returnFunc.type = value.type;
+        return returnFunc;
+      }
+
+      return value;
+    },
+  });
+}

--- a/libs/ngrx-toolkit/src/lib/devtools/tracked-event.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/tracked-event.ts
@@ -1,0 +1,25 @@
+import { EventCreator, event } from '@ngrx/signals/events';
+import { currentActionNames } from './internal/current-action-names';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function trackedEvent<Type extends string>(
+  type: Type,
+): EventCreator<Type, void>;
+
+export function trackedEvent<Type extends string, Payload>(
+  type: Type,
+  payload: Payload,
+): EventCreator<Type, Payload>;
+export function trackedEvent(type: string): EventCreator<string, any> {
+  const originalEvent = event(type);
+  const proxiedCreator = new Proxy(originalEvent, {
+    apply(target, thisArg, argArray) {
+      currentActionNames.add(type);
+      return Reflect.apply(target, thisArg, argArray);
+    },
+  });
+
+  (proxiedCreator as any).type = type;
+
+  return proxiedCreator;
+}


### PR DESCRIPTION
# Proposal: Add `trackedEvent` and `trackedEventGroup`

## Motivation

While working with event-driven patterns in NgRx Signal Store, debugging and tracing dispatched events can become difficult as the application grows.
As withTrackedReducer doesn't detect all dispatched events, only used ones in reducer.

So this proposal introduces:

* `trackedEvent` to be used instead of `event`
* `trackedEventGroup` to be used instead of `eventGroup`

as lightweight wrappers around the existing event creators to track dispatched events using proxy without needing the withTrackedReducer.

---

## Goals

* Preserve the exact same API as the original event creators
* Add transparent event dispatch tracking
* Keep typings fully compatible with existing NgRx Signal Store patterns
* Avoid runtime overhead unless events are actually dispatched

---

## Proposed API

### `trackedEvent`

```ts
export const loadBooks = trackedEvent('[Books] Load Books');
```

```ts
loadBooks();
```

Devtool action:

```txt
[Books] Load Books
```

---

### `trackedEventGroup`

```ts
export const bookEvents = trackedEventGroup({
  source: 'Book Store',
  events: {
    loadBooks: type<void>(),
    bookSelected: type<{ bookId: string }>(),
  },
});
```

```ts
bookEvents.bookSelected({ bookId: '1' });
```

Devtool:

```txt
[Book Store] bookSelected
```
