### PR TITLE
fix(mutations): allow defining the response type (#309)

### DIFF
--- a/libs/ngrx-toolkit/src/lib/mutation/http-mutation.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/mutation/http-mutation.spec.ts
@@ -470,4 +470,28 @@ describe('httpMutation', () => {
       }) satisfies HttpMutation<AddUserEntry, { id: number }>;
     });
   });
+
+  it('should support non-json responseType such as blob', () => {
+    const downloadFile = TestBed.runInInjectionContext(() =>
+      httpMutation<string, Blob>({
+        request: (fileId) => ({
+          url: `/api/files/${fileId}`,
+          method: 'GET',
+          responseType: 'blob',
+        }),
+      }),
+    );
+
+    downloadFile('report-1');
+
+    const req = httpTestingController.expectOne('/api/files/report-1');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.responseType).toBe('blob');
+
+    const mockBlob = new Blob(['file-contents'], { type: 'text/plain' });
+    req.flush(mockBlob);
+
+    expect(downloadFile.status()).toBe('success');
+    expect(downloadFile.value()).toEqual(mockBlob);
+  });
 });

--- a/libs/ngrx-toolkit/src/lib/mutation/http-mutation.ts
+++ b/libs/ngrx-toolkit/src/lib/mutation/http-mutation.ts
@@ -5,6 +5,7 @@ import {
   HttpHeaders,
   HttpParams,
   HttpProgressEvent,
+  HttpRequest,
   HttpResponse,
 } from '@angular/common/http';
 import { inject, Signal, signal } from '@angular/core';
@@ -21,6 +22,7 @@ export type HttpMutationRequest = {
   headers?: HttpHeaders | Record<string, string | string[]>;
   context?: HttpContext;
   reportProgress?: boolean;
+  responseType?: HttpRequest<unknown>['responseType'];
   params?:
     | HttpParams
     | Record<
@@ -139,10 +141,10 @@ export function httpMutation<Parameter, Result>(
         statusCode.set(undefined);
 
         return httpClient
-          .request<Result>(httpRequest.method, httpRequest.url, {
+          .request(httpRequest.method, httpRequest.url, {
             ...httpRequest,
             observe: 'events',
-            responseType: 'json',
+            responseType: httpRequest.responseType ?? 'json',
           })
           .pipe(
             tap((response) => {


### PR DESCRIPTION
Closes https://github.com/angular-architects/ngrx-toolkit/issues/309. Allow setting the `responseType` in `httpMutation`.
